### PR TITLE
Add view helper for publishable key

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -35,6 +35,11 @@ class Module implements ConfigProviderInterface
 
         return [
             'service_manager' => $configProvider->getDependencies(),
+            'view_helpers' => [
+                'factories' => [
+                    'stripeKey' => \ZfrStripeModule\View\Helper\StripeKeyFactory::class,
+                ],
+            ],
         ];
     }
 }

--- a/config/zfr_stripe.local.php.dist
+++ b/config/zfr_stripe.local.php.dist
@@ -24,7 +24,10 @@ return array(
          * Secret key
          */
         // 'secret_key' => '',
-
+        /**
+         * Publishable key
+         */
+        // 'publishable_key' => '',
         /**
          * Stripe SDK version to use
          */

--- a/src/View/Helper/StripeKey.php
+++ b/src/View/Helper/StripeKey.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZfrStripeModule\View\Helper;
+
+use Zend\View\Helper\AbstractHelper;
+
+class StripeKey extends AbstractHelper
+{
+    private $publishableKey;
+
+    public function __construct($publishableKey)
+    {
+        if (strpos($publishableKey, 'sk') === 0) {
+            throw new \Exception('You appear to have set a secret key as your publishable key, please check config');
+        }
+        
+        $this->publishableKey = $publishableKey;
+    }
+
+    public function __invoke()
+    {
+        return sprintf("Stripe.setPublishableKey('%s');", $this->publishableKey);
+    }
+}

--- a/src/View/Helper/StripeKeyFactory
+++ b/src/View/Helper/StripeKeyFactory
@@ -1,0 +1,15 @@
+<?php
+
+namespace ZfrStripeModule\View\Helper;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class StripeKeyFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('Config');
+        return new StripeKey($config['zfr_stripe']['publishable_key']);
+    }
+}


### PR DESCRIPTION
This PR adds a view helper which simplifies adding the stripe publishable key to a view. It can either be called inside a <script> tag or combined with the Zend inline script view helper in a view